### PR TITLE
fixed faulty check if character is available in font

### DIFF
--- a/keras_ocr/data_generation.py
+++ b/keras_ocr/data_generation.py
@@ -130,7 +130,7 @@ def font_supports_alphabet(filepath, alphabet):
     font = PIL.ImageFont.truetype(filepath)
     try:
         for character in alphabet:
-            font.getsize(character)
+            font.getbbox(character)
     # pylint: disable=bare-except
     except:
         return False


### PR DESCRIPTION
the old **getsize()** replaced by **_getbbox_**

       PIL.ImageFont.getsize(c)

as *getsize()* does *not exists* and always leads to an exception.